### PR TITLE
feat: adding new api endpoint to handle user retirement

### DIFF
--- a/ecommerce/extensions/api/v2/urls.py
+++ b/ecommerce/extensions/api/v2/urls.py
@@ -65,6 +65,10 @@ RETIREMENT_URLS = [
     url(r'^tracking_id/{}/$'.format(USERNAME_PATTERN), retirement_views.EcommerceIdView.as_view(), name='tracking_id')
 ]
 
+ECOMMERCE_RETIREMENT_URLS = [
+    url(r'^retire/$', retirement_views.EcommerceUserRetireView.as_view(), name='retire_user')
+]
+
 COUPON_URLS = [
     url(r'^coupon_reports/(?P<coupon_id>[\d]+)/$', CouponReportCSVView.as_view(), name='coupon_reports'),
     url(r'^categories/$', coupon_views.CouponCategoriesListView.as_view(), name='coupons_categories'),
@@ -119,6 +123,7 @@ urlpatterns = [
     url(r'^publication/', include((ATOMIC_PUBLICATION_URLS, 'publication'))),
     url(r'^refunds/', include((REFUND_URLS, 'refunds'))),
     url(r'^retirement/', include((RETIREMENT_URLS, 'retirement'))),
+    url(r'^user/', include((ECOMMERCE_RETIREMENT_URLS, 'ecommerce_retirement'))),
     url(r'^user_management/', include((USER_MANAGEMENT_URLS, 'user_management'))),
     url(r'^assignment-email/', include((ASSIGNMENT_EMAIL_URLS, 'assignment-email'))),
     url(r'^webhooks/', include((WEBHOOKS_URLS, 'webhooks'))),

--- a/ecommerce/extensions/api/v2/views/retirement.py
+++ b/ecommerce/extensions/api/v2/views/retirement.py
@@ -2,9 +2,12 @@
 Endpoints to facilitate retirement actions
 """
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from django.conf import settings
 from rest_framework import permissions, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from social_django.models import UserSocialAuth
+from user_util import user_util
 
 from ecommerce.core.models import User
 from ecommerce.extensions.analytics.utils import ECOM_TRACKING_ID_FMT
@@ -50,4 +53,52 @@ class EcommerceIdView(APIView):
             return Response(
                 status=status.HTTP_404_NOT_FOUND,
                 data={'message': 'Invalid user.'}
+            )
+
+class EcommerceUserRetireView(APIView):
+    """
+    Provides API endpoint for retiring a ecommerce's user.
+    """
+    authentication_classes = (JwtAuthentication,)
+    permission_classes = (permissions.IsAuthenticated, permissions.IsAdminUser)
+
+    def post(self, request):
+        """
+        POST /api/v2/user/retire/
+
+        ```
+        {
+            'username': 'user_to_retire'
+        }
+        ```
+
+        Retires the user with the given username.  This includes
+        retiring this username, retiring the email address, and
+        deleting the social_auth associated with the lms user.
+        """
+        try:
+            username = request.data['username']
+            if not username:
+                raise User.DoesNotExist()
+
+            user = User.objects.get(username=username)
+
+            # Delete social_auth asssociated with the lms user 
+            UserSocialAuth.objects.filter(uid=username).delete()
+
+            # Generate retired email based on retirement settings 
+            user.email = user_util.get_retired_email(user.email, settings.RETIRED_USER_SALTS, settings.RETIRED_EMAIL_FMT)
+            user.username = user_util.get_retired_username(username, settings.RETIRED_USER_SALTS, settings.RETIRED_USERNAME_FMT)
+            user.save()
+
+            return Response(
+                {
+                    'id': user.pk,
+                    'ecommerce_tracking_id': ECOM_TRACKING_ID_FMT.format(user.pk),
+                }
+            )
+        except User.DoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={'message': 'User does not exist on ecommerce service.'}
             )

--- a/ecommerce/settings/base.py
+++ b/ecommerce/settings/base.py
@@ -891,3 +891,17 @@ CAMPAIGN_IDS_BY_EMAIL_TYPE = {
     OfferUsageEmailTypes.LOW_BALANCE: BRAZE_OFFER_LOW_BALANCE_CAMPAIGN,
     OfferUsageEmailTypes.OUT_OF_BALANCE: BRAZE_OFFER_NO_BALANCE_CAMPAIGN
 }
+
+############### Settings for Retirement #####################
+# See annotations in lms/envs/common.py for details.
+RETIRED_USERNAME_PREFIX = 'retired__user_'
+# See annotations in lms/envs/common.py for details.
+RETIRED_EMAIL_PREFIX = 'retired__user_'
+# See annotations in lms/envs/common.py for details.
+RETIRED_EMAIL_DOMAIN = 'retired.invalid'
+# See annotations in lms/envs/common.py for details.
+RETIRED_USERNAME_FMT = 'retired__user_{}'
+# See annotations in lms/envs/common.py for details.
+RETIRED_EMAIL_FMT = 'retired__user_{}@retired.invalid'
+# See annotations in lms/envs/common.py for details.
+RETIRED_USER_SALTS = ['abc', '123']

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -62,6 +62,7 @@ social-auth-app-django
 sorl-thumbnail
 stripe
 unicodecsv
+user-util==1.1.0
 xss-utils
 zeep
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -642,6 +642,8 @@ urllib3==1.26.18
     #   botocore
     #   cybersource-rest-client-python
     #   requests
+user-util==1.1.0
+    # via -r requirements/base.txt
 vine==5.1.0
     # via
     #   amqp

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -659,6 +659,8 @@ urllib3==1.26.18
     #   botocore
     #   cybersource-rest-client-python
     #   requests
+user-util==1.1.0
+    # via -r requirements/base.txt
 vine==5.1.0
     # via
     #   amqp


### PR DESCRIPTION
### Description

Since the ecommerce is deprecated and will be maintained in redwood, this PR was directly made to the NAU fork to add an API endpoint to ecommerce that performs user retirement.

For this, the endpoint [/api/v2/user/retire](https://github.com/openedx/edx-platform/blob/8c40057c1078806e43c8278750ede664309c958c/scripts/user_retirement/utils/edx_api.py#L407). was added, taking advantage of the fact that the function already exists in edx-platform.

As the ecommerce did not store user profile information, this API deletes the social_auth associated with the LMS and modifies both the username and email of the user to comply with the same pattern as in LMS. In this way, the user will be considered retired, and we can compare it with the LMS data if needed to understand how it reached that state.

Regarding validation at the time of authentication, I do not consider it necessary to add a conditional that checks if the user is retired or not, since the ecommerce authentication works via SSO using the LMS and this validation already occurs for retired accounts in the LMS.

If you need to remove or change any user-related data (PII), we can add it to this API to be processed during user retirement process

## Testing instructions

1. Build an ecommerce image with the branch worked on this PR
2. Install [tutor-contrib-retirement fork](https://github.com/fccn/tutor-contrib-retirement/pull/2) with the branch worked on that PR
3. Run a tutor local environment with ecommerce, discovery and retirement activated
4. Declare COOL_OFF_DAYS to 0 so you can test the retirement workflow without wait 30 days (or modify the retirementstatus record directly through mysql)
5. Register, go to account and delete you account
6. Run tutor local retire-users to check the entire retirement workflow

